### PR TITLE
BUG: Wasn't processing all zone updates.

### DIFF
--- a/python/rearview/rpz.py
+++ b/python/rearview/rpz.py
@@ -565,7 +565,10 @@ class RPZ(object):
 
         update = Updater(self.rpz)
 
-        if any( self.prepare_update(update, address, score) for address, score in to_process.values() ):
+        # NOTE: This was using any() which had the unfortunate side effect of bailing the first time
+        #       self.prepare_update() returned True. sum() does the right thing, allowing the entire
+        #       to_process contents to be processed.
+        if sum( self.prepare_update(update, address, score) for address, score in to_process.values() ):
 
             logger['batch_size'] = len(to_process)
             


### PR DESCRIPTION
Introduced at 874962029a9a598fcf51367241466af34639d361 (December 2022)

**Observable:**

Console `refr` shows smaller than expected values for _Wire Size Request_ (around 250-300 bytes). Bear in mind that we are (with the default internal settings) aiming to update the TXT records for 30 associations (target _Batch Size_). Each TXT record should be roughly around 200 bytes, plus the overhead for the request itself. My recollection is that previously these were running 5KB to 10KB in size.